### PR TITLE
Client updates

### DIFF
--- a/fc-client/pom.xml
+++ b/fc-client/pom.xml
@@ -135,6 +135,14 @@
           </execution>
         </executions>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>7</source>
+                <target>7</target>
+            </configuration>
+        </plugin>
     </plugins>
     <resources>
       <resource>

--- a/fc-client/pom.xml
+++ b/fc-client/pom.xml
@@ -74,10 +74,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/fc-client/src/main/java/org/fosstrak/ale/client/FosstrakAleClient.java
+++ b/fc-client/src/main/java/org/fosstrak/ale/client/FosstrakAleClient.java
@@ -51,12 +51,7 @@ import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
 import org.fosstrak.ale.client.cfg.Configuration;
 import org.fosstrak.ale.client.exception.FosstrakAleClientException;
-import org.fosstrak.ale.client.tabs.ALEACClient;
-import org.fosstrak.ale.client.tabs.ALECCClient;
-import org.fosstrak.ale.client.tabs.ALEClient;
-import org.fosstrak.ale.client.tabs.ALELRClient;
-import org.fosstrak.ale.client.tabs.ALETMClient;
-import org.fosstrak.ale.client.tabs.EventSink;
+import org.fosstrak.ale.client.tabs.*;
 
 /**
  * @author swieland
@@ -122,12 +117,15 @@ public class FosstrakAleClient extends JFrame  {
 			tmClient.initialize();
 			ALEACClient acClient = new ALEACClient(this);
 			acClient.initialize();
+			LLRPClient llrpClient = new LLRPClient(this);
+			llrpClient.initialize();
 			
 			m_tab.addTab("Event Cycle", aleClient);
 			m_tab.addTab("Command Cycle", aleCCClient);
 			m_tab.addTab("Logical Reader", lrClient);
 			m_tab.addTab("Tag Memory", tmClient);
 			m_tab.addTab("Access Control", acClient);
+			m_tab.addTab("LLRP", llrpClient);
         } catch (Exception e) {
         	s_log.error("Could not setup basic GUI components.");
         	throw new FosstrakAleClientException(e);

--- a/fc-client/src/main/java/org/fosstrak/ale/client/FosstrakAleClient.java
+++ b/fc-client/src/main/java/org/fosstrak/ale/client/FosstrakAleClient.java
@@ -29,6 +29,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.io.FileNotFoundException;
 import java.util.Properties;
 
 import javax.swing.BorderFactory;
@@ -316,7 +317,7 @@ public class FosstrakAleClient extends JFrame  {
 	/**
 	 * @param args command line arguments.
 	 */
-	public static void main(String[] args) throws FosstrakAleClientException {
+	public static void main(String[] args) throws FosstrakAleClientException, FileNotFoundException {
 		for (String arg : args) {
 			if ("help".equalsIgnoreCase(arg)) help();
 			if ("-h".equalsIgnoreCase(arg)) help();
@@ -326,7 +327,7 @@ public class FosstrakAleClient extends JFrame  {
 		// configure Logger with properties file
 		try {
 			Properties p = new Properties();
-			p.load(FosstrakAleClient.class.getResourceAsStream("/log4j.properties"));
+			p.load(FosstrakAleClient.class.getResourceAsStream("/props/log4j.properties"));
 			PropertyConfigurator.configure(p);
 			s_log.debug("configured the logger.");
 		} catch (Exception e) {

--- a/fc-client/src/main/java/org/fosstrak/ale/client/FosstrakEventSinkStandalone.java
+++ b/fc-client/src/main/java/org/fosstrak/ale/client/FosstrakEventSinkStandalone.java
@@ -1,5 +1,6 @@
 package org.fosstrak.ale.client;
 
+import java.io.FileNotFoundException;
 import java.net.URL;
 import java.util.Properties;
 
@@ -57,7 +58,7 @@ public class FosstrakEventSinkStandalone extends JFrame {
 	/**
 	 * @param args
 	 */
-	public static void main(String[] args) throws FosstrakAleClientException {
+	public static void main(String[] args) throws FosstrakAleClientException, FileNotFoundException {
 		for (String arg : args) {
 			if ("help".equalsIgnoreCase(arg)) help();
 			if ("-h".equalsIgnoreCase(arg)) help();

--- a/fc-client/src/main/java/org/fosstrak/ale/client/cfg/Configuration.java
+++ b/fc-client/src/main/java/org/fosstrak/ale/client/cfg/Configuration.java
@@ -163,6 +163,14 @@ public class Configuration {
 	public int getPropertyAsInteger(String key) {
 		return Integer.parseInt(m_properties.getProperty(key));
 	}
+
+	/**
+	 * @param key the key (eg. org.fosstrak.ale.client.windowHeight).
+	 * @return a property uniquely identified by the given key.
+	 */
+	public boolean getPropertyAsBoolean(String key) {
+		return Boolean.parseBoolean(m_properties.getProperty(key, "false"));
+	}
 	
 	/**
 	 * @return the font specified in the configuration. the font is created only once and is 

--- a/fc-client/src/main/java/org/fosstrak/ale/client/tabs/ALEACClient.java
+++ b/fc-client/src/main/java/org/fosstrak/ale/client/tabs/ALEACClient.java
@@ -223,6 +223,7 @@ public class ALEACClient extends AbstractTab {
 		m_specNameComboBox = new JComboBox();
 		m_specNameComboBox.setFont(m_font);
 		m_specNameComboBox.setEditable(false);
+		m_specNameComboBox.addItem(null);
 
 		List<String> ecSpecNames = null;
 		try {
@@ -233,9 +234,11 @@ public class ALEACClient extends AbstractTab {
 			for (String specName : ecSpecNames) {
 				m_specNameComboBox.addItem(specName);
 			}
+			m_specNameComboBox.setSelectedIndex(1);
 		} else {
 			m_specNameComboBox.addItem("no specs defined");
 		}
+
 		JLabel lbl = new JLabel(m_guiText.getString("SpecNameLabel"));
 		lbl.setFont(m_font);
 		panel.add(lbl);

--- a/fc-client/src/main/java/org/fosstrak/ale/client/tabs/ALECCClient.java
+++ b/fc-client/src/main/java/org/fosstrak/ale/client/tabs/ALECCClient.java
@@ -220,6 +220,7 @@ public class ALECCClient extends AbstractTab {
 		m_specNameComboBox = new JComboBox();
 		m_specNameComboBox.setFont(m_font);
 		m_specNameComboBox.setEditable(false);
+		m_specNameComboBox.addItem(null);
 
 		List<String> ccSpecNames = null;
 		try {
@@ -230,9 +231,11 @@ public class ALECCClient extends AbstractTab {
 			for (String specName : ccSpecNames) {
 				m_specNameComboBox.addItem(specName);
 			}
+			m_specNameComboBox.setSelectedIndex(1);
 		} else {
 			m_specNameComboBox.addItem("no specs defined");
 		}
+
 		JLabel lbl = new JLabel(m_guiText.getString("SpecNameLabel"));
 		lbl.setFont(m_font);
 		panel.add(lbl);

--- a/fc-client/src/main/java/org/fosstrak/ale/client/tabs/ALEClient.java
+++ b/fc-client/src/main/java/org/fosstrak/ale/client/tabs/ALEClient.java
@@ -220,6 +220,7 @@ public class ALEClient extends AbstractTab {
 		m_specNameComboBox = new JComboBox();
 		m_specNameComboBox.setFont(m_font);
 		m_specNameComboBox.setEditable(false);
+		m_specNameComboBox.addItem(null);
 
 		List<String> ecSpecNames = null;
 		try {
@@ -230,9 +231,11 @@ public class ALEClient extends AbstractTab {
 			for (String specName : ecSpecNames) {
 				m_specNameComboBox.addItem(specName);
 			}
+			m_specNameComboBox.setSelectedIndex(1);
 		} else {
 			m_specNameComboBox.addItem("no specs defined");
 		}
+
 		JLabel lbl = new JLabel(m_guiText.getString("SpecNameLabel"));
 		lbl.setFont(m_font);
 		panel.add(lbl);

--- a/fc-client/src/main/java/org/fosstrak/ale/client/tabs/ALELRClient.java
+++ b/fc-client/src/main/java/org/fosstrak/ale/client/tabs/ALELRClient.java
@@ -184,6 +184,7 @@ public class ALELRClient extends AbstractTab {
 		
 		m_specNameComboBox = new JComboBox();
 		m_specNameComboBox.setFont(m_font);
+		m_specNameComboBox.setEditable(false);
 		m_specNameComboBox.addItem(null);
 		
 		List<String> lrSpecNames = null;
@@ -195,6 +196,7 @@ public class ALELRClient extends AbstractTab {
 			for (String specName : lrSpecNames) {
 				m_specNameComboBox.addItem(specName);
 			}
+			m_specNameComboBox.setSelectedIndex(1);
 		} else {
 			m_specNameComboBox.addItem("no specs defined");
 		}

--- a/fc-client/src/main/java/org/fosstrak/ale/client/tabs/ALETMClient.java
+++ b/fc-client/src/main/java/org/fosstrak/ale/client/tabs/ALETMClient.java
@@ -193,6 +193,7 @@ public class ALETMClient extends AbstractTab {
 		m_specNameComboBox = new JComboBox();
 		m_specNameComboBox.setFont(m_font);
 		m_specNameComboBox.setEditable(false);
+		m_specNameComboBox.addItem(null);
 
 		List<String> ecSpecNames = null;
 		try {
@@ -203,9 +204,11 @@ public class ALETMClient extends AbstractTab {
 			for (String specName : ecSpecNames) {
 				m_specNameComboBox.addItem(specName);
 			}
+			m_specNameComboBox.setSelectedIndex(1);
 		} else {
 			m_specNameComboBox.addItem("no specs defined");
 		}
+
 		JLabel lbl = new JLabel(m_guiText.getString("SpecNameLabel"));
 		lbl.setFont(m_font);
 		panel.add(lbl);

--- a/fc-client/src/main/java/org/fosstrak/ale/client/tabs/AbstractTab.java
+++ b/fc-client/src/main/java/org/fosstrak/ale/client/tabs/AbstractTab.java
@@ -237,6 +237,7 @@ public abstract class AbstractTab extends JPanel {
 				outProps.put(WSHandlerConstants.USER, userId);
 				outProps.put(WSHandlerConstants.PW_CALLBACK_REF, cpc);
 				outProps.put(WSHandlerConstants.PASSWORD_TYPE, WSConstants.PW_TEXT);
+				outProps.put(WSHandlerConstants.MUST_UNDERSTAND, "false");
 
 				WSS4JOutInterceptor wssOut = new WSS4JOutInterceptor(outProps);
 
@@ -247,13 +248,15 @@ public abstract class AbstractTab extends JPanel {
 
 			m_proxy = toReturn;
 			
-			// We try to perform a test method call.
-			// If that call fails, we assume the connection to be down.
-			try {
-				m_testMethod.invoke(m_proxy, m_testMethodParameter);
-			} catch (Exception e) {
-				m_proxy = null;
-				throw new FosstrakAleClientServiceDownException(e);
+			// We try to perform a test method call (if it's defined)
+			if (m_testMethod != null) {
+				// If that call fails, we assume the connection to be down.
+				try {
+					m_testMethod.invoke(m_proxy, m_testMethodParameter);
+				} catch (Exception e) {
+					m_proxy = null;
+					throw new FosstrakAleClientServiceDownException(e);
+				}
 			}
 		}
 		return m_proxy;

--- a/fc-client/src/main/java/org/fosstrak/ale/client/tabs/AbstractTab.java
+++ b/fc-client/src/main/java/org/fosstrak/ale/client/tabs/AbstractTab.java
@@ -200,55 +200,55 @@ public abstract class AbstractTab extends JPanel {
 	protected Object getProxy() throws FosstrakAleClientException {
 		if (null == m_proxy) {
 
-			// Needed to get rig of CXF exception
-			// "Cannot create a secure XMLInputFactory"
+			// Needed to get rid of CXF exception: "Cannot create a secure XMLInputFactory"
+			// Doesn't matter if security is used or not
 			System.setProperty("org.apache.cxf.stax.allowInsecureParser", "true");
 
-			// display the connect dialog
+			// display the connection endpoint dialog
 			String address = FosstrakAleClient.instance().showConnectDialog(m_endpointKey);
-			
-			// create the proxy object.
-			
-			String userId = FosstrakAleClient.instance().getConfiguration().getProperty("userId");
-			
+
+			// Create service factory
 			JaxWsProxyFactoryBean factory;
 			factory = new JaxWsProxyFactoryBean();
 			factory.setServiceClass(m_clzz);
 			factory.setAddress(address);
-			
 			Object toReturn = factory.create();
-			
-			CallbackHandler cpc = new CallbackHandler() {
 
-				@Override
-				public void handle(Callback[] callbacks) throws IOException,
-						UnsupportedCallbackException {
-					WSPasswordCallback pc = (WSPasswordCallback)callbacks[0];
-					String password = FosstrakAleClient.instance().getConfiguration().getProperty("password");
-					pc.setPassword(password);
-					
-				}
-				
-			};
+			// Use SOAP WS-Security or not ?
+			boolean useWsse = FosstrakAleClient.instance().getConfiguration().getPropertyAsBoolean("useWsse");
+			if (useWsse) {
 
-			Map<String, Object> outProps = new HashMap<String, Object>();
-			outProps.put(WSHandlerConstants.ACTION, WSHandlerConstants.USERNAME_TOKEN);
-			outProps.put(WSHandlerConstants.USER, userId);
-			outProps.put(WSHandlerConstants.PW_CALLBACK_REF, cpc);
-			outProps.put(WSHandlerConstants.PASSWORD_TYPE, WSConstants.PW_TEXT);
-			
-			WSS4JOutInterceptor wssOut = new WSS4JOutInterceptor(outProps);
-			
-			
-			Client c = ClientProxy.getClient(toReturn);
-			Endpoint cxfEndpoint = c.getEndpoint();
-			cxfEndpoint.getOutInterceptors().add(wssOut);
-			
-			
+				// Get username and password from configuration
+				String userId = FosstrakAleClient.instance().getConfiguration().getProperty("userId");
+				CallbackHandler cpc = new CallbackHandler() {
+
+					@Override
+					public void handle(Callback[] callbacks) throws IOException,
+							UnsupportedCallbackException {
+						WSPasswordCallback pc = (WSPasswordCallback) callbacks[0];
+						String password = FosstrakAleClient.instance().getConfiguration().getProperty("password");
+						pc.setPassword(password);
+					}
+
+				};
+
+				Map<String, Object> outProps = new HashMap<String, Object>();
+				outProps.put(WSHandlerConstants.ACTION, WSHandlerConstants.USERNAME_TOKEN);
+				outProps.put(WSHandlerConstants.USER, userId);
+				outProps.put(WSHandlerConstants.PW_CALLBACK_REF, cpc);
+				outProps.put(WSHandlerConstants.PASSWORD_TYPE, WSConstants.PW_TEXT);
+
+				WSS4JOutInterceptor wssOut = new WSS4JOutInterceptor(outProps);
+
+				Client c = ClientProxy.getClient(toReturn);
+				Endpoint cxfEndpoint = c.getEndpoint();
+				cxfEndpoint.getOutInterceptors().add(wssOut);
+			}
+
 			m_proxy = toReturn;
 			
-			// we try to perform a test method call.
-			// if that call fails, we assume the connection to be down.
+			// We try to perform a test method call.
+			// If that call fails, we assume the connection to be down.
 			try {
 				m_testMethod.invoke(m_proxy, m_testMethodParameter);
 			} catch (Exception e) {

--- a/fc-client/src/main/java/org/fosstrak/ale/client/tabs/AbstractTab.java
+++ b/fc-client/src/main/java/org/fosstrak/ale/client/tabs/AbstractTab.java
@@ -199,6 +199,11 @@ public abstract class AbstractTab extends JPanel {
 	 */
 	protected Object getProxy() throws FosstrakAleClientException {
 		if (null == m_proxy) {
+
+			// Needed to get rig of CXF exception
+			// "Cannot create a secure XMLInputFactory"
+			System.setProperty("org.apache.cxf.stax.allowInsecureParser", "true");
+
 			// display the connect dialog
 			String address = FosstrakAleClient.instance().showConnectDialog(m_endpointKey);
 			
@@ -208,7 +213,7 @@ public abstract class AbstractTab extends JPanel {
 			
 			JaxWsProxyFactoryBean factory;
 			factory = new JaxWsProxyFactoryBean();
-			factory.setServiceClass(ALETMServicePortType.class);
+			factory.setServiceClass(m_clzz);
 			factory.setAddress(address);
 			
 			Object toReturn = factory.create();
@@ -243,7 +248,7 @@ public abstract class AbstractTab extends JPanel {
 			m_proxy = toReturn;
 			
 			// we try to perform a test method call.
-			// if that call fails, we assume the connection to be daad.
+			// if that call fails, we assume the connection to be down.
 			try {
 				m_testMethod.invoke(m_proxy, m_testMethodParameter);
 			} catch (Exception e) {

--- a/fc-client/src/main/java/org/fosstrak/ale/client/tabs/LLRPClient.java
+++ b/fc-client/src/main/java/org/fosstrak/ale/client/tabs/LLRPClient.java
@@ -184,6 +184,7 @@ public class LLRPClient extends AbstractTab {
         m_specNameComboBox = new JComboBox();
         m_specNameComboBox.setFont(m_font);
         m_specNameComboBox.setEditable(false);
+        m_specNameComboBox.addItem(null);
 
         List<String> roSpecNames = null;
         try {
@@ -194,9 +195,11 @@ public class LLRPClient extends AbstractTab {
             for (String specName : roSpecNames) {
                 m_specNameComboBox.addItem(specName);
             }
+            m_specNameComboBox.setSelectedIndex(1);
         } else {
             m_specNameComboBox.addItem("no specs defined");
         }
+
         JLabel lbl = new JLabel(m_guiText.getString("SpecNameLabel"));
         lbl.setFont(m_font);
         panel.add(lbl);
@@ -248,10 +251,9 @@ public class LLRPClient extends AbstractTab {
                 case CMD__ENABLE_LLRP:
                 case CMD__DISABLE_LLRP:
                     // get specName
-                    specName = m_specNameValueField.getText();
+                    specName = (String)m_specNameComboBox.getSelectedItem();
                     if (specName == null || "".equals(specName)) {
-                        FosstrakAleClient.instance().showExceptionDialog(
-                                m_guiText.getString("SpecNameNotSpecifiedDialog"));
+                        FosstrakAleClient.instance().showExceptionDialog(m_guiText.getString("SpecNameNotSpecifiedDialog"));
                         break;
                     }
 

--- a/fc-client/src/main/java/org/fosstrak/ale/client/tabs/LLRPClient.java
+++ b/fc-client/src/main/java/org/fosstrak/ale/client/tabs/LLRPClient.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright (C) 2021 Krakul OÜ
+ * @author Mikk Leini <mikk.leini@krakul.eu>
+ *
+ * Copyright (C) 2014 KAIST
+ * @author Janggwan Im <limg00n@kaist.ac.kr>
+ *
+ * Copyright (C) 2007 ETH Zurich
+ *
+ * This file is part of Fosstrak (www.fosstrak.org).
+ *
+ * Fosstrak is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software Foundation.
+ *
+ * Fosstrak is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Fosstrak; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA
+ */
+
+package org.fosstrak.ale.client.tabs;
+
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.CharArrayWriter;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.swing.BorderFactory;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.xml.ws.soap.SOAPFaultException;
+import org.apache.log4j.Logger;
+
+import org.fosstrak.ale.client.FosstrakAleClient;
+import org.fosstrak.ale.server.llrp.LLRPController;
+import org.fosstrak.ale.client.exception.FosstrakAleClientException;
+import org.fosstrak.ale.client.exception.FosstrakAleClientServiceDownException;
+import org.fosstrak.ale.util.DeserializerUtil;
+import org.fosstrak.ale.util.SerializerUtil;
+import org.fosstrak.ale.wsdl.ale.epcglobal.ArrayOfString;
+import org.fosstrak.ale.wsdl.ale.epcglobal.Immediate;
+import org.fosstrak.ale.wsdl.ale.epcglobal.DuplicateNameExceptionResponse;
+import org.fosstrak.ale.wsdl.ale.epcglobal.ImplementationExceptionResponse;
+import org.fosstrak.ale.wsdl.ale.epcglobal.NoSuchNameExceptionResponse;
+import org.fosstrak.ale.wsdl.ale.epcglobal.SecurityExceptionResponse;
+import org.fosstrak.ale.wsdl.ale.epcglobal.EmptyParms;
+import org.llrp.ltk.generated.messages.ADD_ROSPEC;
+
+/**
+ * This class implements a graphical user interface for the Application Level
+ * Events (ALE) client. The client send all commands as SOAP messages to the ALE
+ * server. This class configures LLRP controller in the ALE server.
+ */
+public class LLRPClient extends AbstractTab {
+
+    /**
+     * endpoint parameter for the configuration.
+     */
+    public static final String CFG_ENDPOINT = "org.fosstrak.ale.client.llrp.endpoint";
+
+    /**
+     * text field which contains the reader name.
+     */
+    private JTextField m_specNameValueField;
+
+    // logger.
+    private static final Logger s_log = Logger.getLogger(LLRPClient.class);
+
+    private static final int CMD__DEFINE_LLRP = 1;
+    private static final int CMD__UNDEFINE_LLRP = 2;
+    private static final int CMD__START_LLRP = 3;
+    private static final int CMD__STOP_LLRP = 4;
+    private static final int CMD__ENABLE_LLRP = 5;
+    private static final int CMD__DISABLE_LLRP = 6;
+    private static final int CMD__DISABLE_ALL_LLRP = 7;
+
+    /**
+     * @param parent the parent frame.
+     * @throws NoSuchMethodException given to the fact that we need to pass in a test method via reflection.
+     * @throws SecurityException given to the fact that we need to pass in a test method via reflection.
+     */
+    public LLRPClient(JFrame parent) throws SecurityException, NoSuchMethodException {
+        super(LLRPController.class, CFG_ENDPOINT, parent, null, null);
+    }
+
+    @Override
+    public String getBaseNameKey() {
+        return "org.fosstrak.ale.client.llrp.lang.base";
+    }
+
+    @Override
+    protected void setCommandPanel(int command) {
+
+        if (command == CMD__UNDEFINED_COMMAND) {
+            m_commandPanel.removeAll();
+            m_commandPanel.setBorder(null);
+            this.setVisible(false);
+            this.setVisible(true);
+            return;
+        }
+
+        m_commandPanel.setBorder(BorderFactory.createCompoundBorder(
+                BorderFactory.createTitledBorder(m_guiText.getString("Command" + command)),
+                BorderFactory.createEmptyBorder(5, 5, 5, 5)));
+        m_commandPanel.removeAll();
+
+        switch (command) {
+
+            case CMD__DEFINE_LLRP:
+                m_commandPanel.setLayout(new GridLayout(8, 1, 5, 0));
+                addSpecNameValueField(m_commandPanel);
+                addChooseFileField(m_commandPanel);
+                addSeparator(m_commandPanel);
+                break;
+
+            case CMD__UNDEFINE_LLRP:
+            case CMD__START_LLRP:
+            case CMD__STOP_LLRP:
+            case CMD__ENABLE_LLRP:
+            case CMD__DISABLE_LLRP:
+                m_commandPanel.setLayout(new GridLayout(5, 1, 5, 0));
+                addSpecNameValueField(m_commandPanel);
+                addSeparator(m_commandPanel);
+                break;
+
+            case CMD__DISABLE_ALL_LLRP:
+                m_commandPanel.setLayout(new GridLayout(1, 1, 5, 0));
+                break;
+        }
+
+        m_commandPanel.setFont(m_font);
+        addExecuteButton(m_commandPanel);
+
+        validate();
+        this.setVisible(true);
+    }
+
+    /**
+     * This method adds a notification property value field to the panel.
+     *
+     * @param panel to which the property value field should be added
+     */
+    private void addSpecNameValueField(JPanel panel) {
+
+        m_specNameValueField = new JTextField();
+        m_specNameValueField.setFont(m_font);
+
+        JLabel lbl = new JLabel(m_guiText.getString("SpecNameLabel"));
+        lbl.setFont(m_font);
+        panel.add(lbl);
+        panel.add(m_specNameValueField);
+    }
+
+    @Override
+    protected void executeCommand() {
+
+        Object result = null;
+        String specName = null;
+        Exception ex = null;
+
+        try {
+
+            switch (m_commandSelection.getSelectedIndex()) {
+
+                case CMD__DEFINE_LLRP:
+                    // get specName
+                    specName = m_specNameValueField.getText();
+                    if (specName == null || "".equals(specName)) {
+                        FosstrakAleClient.instance().showExceptionDialog(
+                                m_guiText.getString("SpecNameNotSpecifiedDialog"));
+                        break;
+                    }
+
+                    // get filePath
+                    String filePath = m_filePathField.getText();
+                    if (filePath == null || "".equals(filePath)) {
+                        FosstrakAleClient.instance().showExceptionDialog(m_guiText.getString("FilePathNotSpecifiedDialog"));
+                        break;
+                    }
+
+                    // File exists?
+                    if (Files.notExists(Paths.get(filePath)))
+                    {
+                        FosstrakAleClient.instance().showExceptionDialog(m_guiText.getString("FileNotFoundDialog"));
+                        break;
+                    }
+
+                    // Define
+                    getLLRPServiceProxy().define(specName, filePath);
+                    result = m_guiText.getString("SuccessfullyDefinedMessage");
+                    break;
+
+                case CMD__UNDEFINE_LLRP:
+                case CMD__START_LLRP:
+                case CMD__STOP_LLRP:
+                case CMD__ENABLE_LLRP:
+                case CMD__DISABLE_LLRP:
+                    // get specName
+                    specName = m_specNameValueField.getText();
+                    if (specName == null || "".equals(specName)) {
+                        FosstrakAleClient.instance().showExceptionDialog(
+                                m_guiText.getString("SpecNameNotSpecifiedDialog"));
+                        break;
+                    }
+
+                    switch (m_commandSelection.getSelectedIndex()) {
+                        case CMD__UNDEFINE_LLRP:
+                            getLLRPServiceProxy().undefine(specName);
+                            break;
+
+                        case CMD__START_LLRP:
+                            getLLRPServiceProxy().start(specName);
+                            break;
+
+                        case CMD__STOP_LLRP:
+                            getLLRPServiceProxy().stop(specName);
+                            break;
+
+                        case CMD__ENABLE_LLRP:
+                            getLLRPServiceProxy().enable(specName);
+                            break;
+
+                        case CMD__DISABLE_LLRP:
+                            getLLRPServiceProxy().disable(specName);
+                            break;
+                    }
+
+                    break;
+
+                case CMD__DISABLE_ALL_LLRP:
+                    getLLRPServiceProxy().disableAll();
+                    break;
+            }
+
+        } catch (Exception e) {
+            String reason = e.getMessage();
+
+            String text = "Unknown Error";
+            if (e instanceof DuplicateNameExceptionResponse) {
+                text = m_guiText.getString("DuplicateNameExceptionDialog");
+            } else if (e instanceof ImplementationExceptionResponse) {
+                text = m_guiText.getString("ImplementationExceptionDialog");
+            } else if (e instanceof NoSuchNameExceptionResponse) {
+                text = m_guiText.getString("NoSuchNameExceptionDialog");
+            } else if (e instanceof SecurityExceptionResponse) {
+                text = m_guiText.getString("SecurityExceptionDialog");
+            } else if (e instanceof SOAPFaultException) {
+                text = "Service error";
+            } else if (e instanceof FosstrakAleClientServiceDownException) {
+                text = "Unable to execute command.";
+                reason = "Service is down or endpoint wrong.";
+            }
+
+            FosstrakAleClient.instance().showExceptionDialog(text, reason);
+            ex = e;
+        }
+
+        if (null == ex) {
+            showResult(result);
+        } else {
+            showResult(ex);
+        }
+    }
+
+    /**
+     * This method loads the ADD_ROSPEC specification from a file.
+     *
+     * @param filename of ec specification file
+     * @return ec specification
+     * @throws Exception if specification could not be loaded
+     */
+    private ADD_ROSPEC getADDROSPECFromFile(String filename) throws Exception {
+        FileInputStream inputStream = new FileInputStream(filename);
+        return DeserializerUtil.deserializeAddROSpec(inputStream);
+    }
+
+    @Override
+    protected void decodeResult(StringBuffer sb, Object result) {
+        if (result instanceof ArrayOfString) {
+            ArrayOfString resultStringArray = (ArrayOfString) result;
+            if (resultStringArray.getString().size() == 0) {
+                sb.append(m_guiText.getString("EmptyArray"));
+            } else {
+                for (String s : resultStringArray.getString()) {
+                    sb.append(s);
+                    sb.append("\n");
+                }
+            }
+        }
+    }
+
+    @Override
+    protected String[] getCommands() {
+
+        String[] commands = new String[7];
+        for (int i = 1; i <= 7; i++) {
+            commands[i - 1] = m_guiText.getString("Command" + i);
+        }
+        return commands;
+    }
+
+    /**
+     * @return returns the proxy object already casted.
+     */
+    protected LLRPController getLLRPServiceProxy() throws FosstrakAleClientException {
+
+        return (LLRPController) getProxy();
+    }
+}

--- a/fc-client/src/main/resources/props/LLRPClient_en.lang
+++ b/fc-client/src/main/resources/props/LLRPClient_en.lang
@@ -1,0 +1,47 @@
+ApplicationTitle = LLRP Client - Reader API
+
+FileMenu = File
+QuitMenuItem = Quit
+
+SelectionPanelTitle = Select Command
+ResultPanelTitle = Result
+
+SpecNameLabel = Specification Name
+FilePathLabel = Specification File Path
+ChooseFileButtonLabel = Choose File
+
+ExecuteButtonLabel = execute
+OkButtonLabel = OK
+
+CreateEventSink = Create Event Sink
+
+SuccessfullyDefinedMessage = The specification is successfully defined.
+SuccessfullyUndefinedMessage = The specification is successfully undefined.
+NoSpecDefinedMessage = There are no specifications defined.
+NoSubscribersMessage = There are no subscribers subscribed.
+EmptyArray = There are no result items.
+
+ExceptionDialogTitle = Exception
+ConnectionExceptionDialog = Could not connect to the specified endpoint.
+SpecNameNotSpecifiedDialog = Please specify the specification name.
+FilePathNotSpecifiedDialog = Please specify the specification file path. 
+NotificationUriNotSpecifiedDialog = Please specify the notification uri.
+FileNotFoundDialog = The specified file does not exist.
+UnexpectedFileFormatDialog = The specified file has an unexpected format.
+DuplicateNameExceptionDialog = The specified specification name does already exist.
+ADD_ROSpecValidationExceptionDialog = The specification is invalid.
+ImplementationExceptionDialog = An implementation exception occured.
+InvalidURIExceptionDialog = The specified URI is invalid.
+NoSuchNameExceptionDialog = The specified specification name does not exist.
+SecurityExceptionDialog = A security exception occured.
+UnknownExceptionDialog = An unknown exception occured.
+SerializationExceptionMessage = Could not serialize the result.
+DetailsPanelTitle = Exception Details
+
+Command1 = define
+Command2 = undefine
+Command3 = start
+Command4 = stop
+Command5 = enable
+Command6 = disable
+Command7 = disableAll

--- a/fc-client/src/main/resources/props/LLRPClient_en.lang
+++ b/fc-client/src/main/resources/props/LLRPClient_en.lang
@@ -40,8 +40,9 @@ DetailsPanelTitle = Exception Details
 
 Command1 = define
 Command2 = undefine
-Command3 = start
-Command4 = stop
-Command5 = enable
-Command6 = disable
-Command7 = disableAll
+Command3 = readSpecNames
+Command4 = start
+Command5 = stop
+Command6 = enable
+Command7 = disable
+Command8 = disableAll

--- a/fc-client/src/main/resources/props/client.properties
+++ b/fc-client/src/main/resources/props/client.properties
@@ -11,32 +11,32 @@ org.fosstrak.ale.client.font=Verdana
 org.fosstrak.ale.client.font.size=10
 
 # default end-point for the ALEService
-org.fosstrak.ale.client.ale.endpoint=http://localhost:8080/fc-server/services/ALEService
+org.fosstrak.ale.client.ale.endpoint=http://localhost:8080/fc-server-${project.version}/services/ALEService
 # default language pack for the Event Cycle Management GUI
 org.fosstrak.ale.client.ale.lang.base=/props/ALEClient
 
 # default end-point for the ALECCService
-org.fosstrak.ale.client.alecc.endpoint=http://localhost:8080/fc-server/services/ALECCService
+org.fosstrak.ale.client.alecc.endpoint=http://localhost:8080/fc-server-${project.version}/services/ALECCService
 # default language pack for the Command Cycle Management GUI
 org.fosstrak.ale.client.alecc.lang.base=/props/ALECCClient
 
 # default end-point for the ALELRService
-org.fosstrak.ale.client.alelr.endpoint=http://localhost:8080/fc-server/services/ALELRService
+org.fosstrak.ale.client.alelr.endpoint=http://localhost:8080/fc-server-${project.version}/services/ALELRService
 # default language pack for the Logical Reader Management GUI
 org.fosstrak.ale.client.alelr.lang.base=/props/ALELRClient
 
 # default end-point for the ALETMService
-org.fosstrak.ale.client.aletm.endpoint=http://localhost:8080/fc-server/services/ALETMService
+org.fosstrak.ale.client.aletm.endpoint=http://localhost:8080/fc-server-${project.version}/services/ALETMService
 # default language pack for the Tag Memory Management GUI
 org.fosstrak.ale.client.aletm.lang.base=/props/ALETMClient
 
 # default end-point for the ALEACService
-org.fosstrak.ale.client.aleac.endpoint=http://localhost:8080/fc-server/services/ALEACService
+org.fosstrak.ale.client.aleac.endpoint=http://localhost:8080/fc-server/services-${project.version}/ALEACService
 # default language pack for the Access Control Management GUI
 org.fosstrak.ale.client.aleac.lang.base=/props/ALEACClient
 
 # default end-point for the LLRPService
-org.fosstrak.ale.client.llrp.endpoint=http://localhost:8080/fc-server/services/LLRPControllerService
+org.fosstrak.ale.client.llrp.endpoint=http://localhost:8080/fc-server/services-${project.version}/LLRPControllerService
 # default language pack for the Access Control Management GUI
 org.fosstrak.ale.client.llrp.lang.base=/props/LLRPClient
 

--- a/fc-client/src/main/resources/props/client.properties
+++ b/fc-client/src/main/resources/props/client.properties
@@ -36,6 +36,7 @@ org.fosstrak.ale.client.aleac.endpoint=http://localhost:8080/fc-server-${project
 org.fosstrak.ale.client.aleac.lang.base=/props/ALEACClient
 
 
-# userId and password for login
+# useWsse (SOAP WS-Security), userId and password for login
+useWsse=true
 userId=admin
 password=1111

--- a/fc-client/src/main/resources/props/client.properties
+++ b/fc-client/src/main/resources/props/client.properties
@@ -31,12 +31,12 @@ org.fosstrak.ale.client.aletm.endpoint=http://localhost:8080/fc-server-${project
 org.fosstrak.ale.client.aletm.lang.base=/props/ALETMClient
 
 # default end-point for the ALEACService
-org.fosstrak.ale.client.aleac.endpoint=http://localhost:8080/fc-server/services-${project.version}/ALEACService
+org.fosstrak.ale.client.aleac.endpoint=http://localhost:8080/fc-server-${project.version}/services/ALEACService
 # default language pack for the Access Control Management GUI
 org.fosstrak.ale.client.aleac.lang.base=/props/ALEACClient
 
 # default end-point for the LLRPService
-org.fosstrak.ale.client.llrp.endpoint=http://localhost:8080/fc-server/services-${project.version}/LLRPControllerService
+org.fosstrak.ale.client.llrp.endpoint=http://localhost:8080/fc-server-${project.version}/services/LLRPControllerService
 # default language pack for the Access Control Management GUI
 org.fosstrak.ale.client.llrp.lang.base=/props/LLRPClient
 

--- a/fc-client/src/main/resources/props/client.properties
+++ b/fc-client/src/main/resources/props/client.properties
@@ -35,6 +35,10 @@ org.fosstrak.ale.client.aleac.endpoint=http://localhost:8080/fc-server-${project
 # default language pack for the Access Control Management GUI
 org.fosstrak.ale.client.aleac.lang.base=/props/ALEACClient
 
+# default end-point for the LLRPService
+org.fosstrak.ale.client.llrp.endpoint=http://localhost:8080/fc-server-${project.version}/services/LLRPControllerService
+# default language pack for the Access Control Management GUI
+org.fosstrak.ale.client.llrp.lang.base=/props/LLRPClient
 
 # useWsse (SOAP WS-Security), userId and password for login
 useWsse=true

--- a/fc-client/src/main/resources/props/client.properties
+++ b/fc-client/src/main/resources/props/client.properties
@@ -11,32 +11,32 @@ org.fosstrak.ale.client.font=Verdana
 org.fosstrak.ale.client.font.size=10
 
 # default end-point for the ALEService
-org.fosstrak.ale.client.ale.endpoint=http://localhost:8080/fc-server-${project.version}/services/ALEService
+org.fosstrak.ale.client.ale.endpoint=http://localhost:8080/fc-server/services/ALEService
 # default language pack for the Event Cycle Management GUI
 org.fosstrak.ale.client.ale.lang.base=/props/ALEClient
 
 # default end-point for the ALECCService
-org.fosstrak.ale.client.alecc.endpoint=http://localhost:8080/fc-server-${project.version}/services/ALECCService
+org.fosstrak.ale.client.alecc.endpoint=http://localhost:8080/fc-server/services/ALECCService
 # default language pack for the Command Cycle Management GUI
 org.fosstrak.ale.client.alecc.lang.base=/props/ALECCClient
 
 # default end-point for the ALELRService
-org.fosstrak.ale.client.alelr.endpoint=http://localhost:8080/fc-server-${project.version}/services/ALELRService
+org.fosstrak.ale.client.alelr.endpoint=http://localhost:8080/fc-server/services/ALELRService
 # default language pack for the Logical Reader Management GUI
 org.fosstrak.ale.client.alelr.lang.base=/props/ALELRClient
 
 # default end-point for the ALETMService
-org.fosstrak.ale.client.aletm.endpoint=http://localhost:8080/fc-server-${project.version}/services/ALETMService
+org.fosstrak.ale.client.aletm.endpoint=http://localhost:8080/fc-server/services/ALETMService
 # default language pack for the Tag Memory Management GUI
 org.fosstrak.ale.client.aletm.lang.base=/props/ALETMClient
 
 # default end-point for the ALEACService
-org.fosstrak.ale.client.aleac.endpoint=http://localhost:8080/fc-server-${project.version}/services/ALEACService
+org.fosstrak.ale.client.aleac.endpoint=http://localhost:8080/fc-server/services/ALEACService
 # default language pack for the Access Control Management GUI
 org.fosstrak.ale.client.aleac.lang.base=/props/ALEACClient
 
 # default end-point for the LLRPService
-org.fosstrak.ale.client.llrp.endpoint=http://localhost:8080/fc-server-${project.version}/services/LLRPControllerService
+org.fosstrak.ale.client.llrp.endpoint=http://localhost:8080/fc-server/services/LLRPControllerService
 # default language pack for the Access Control Management GUI
 org.fosstrak.ale.client.llrp.lang.base=/props/LLRPClient
 

--- a/fc-commons/src/main/java/org/fosstrak/ale/server/llrp/LLRPController.java
+++ b/fc-commons/src/main/java/org/fosstrak/ale/server/llrp/LLRPController.java
@@ -2,6 +2,7 @@ package org.fosstrak.ale.server.llrp;
 
 import javax.jws.WebMethod;
 import javax.jws.WebService;
+import java.util.List;
 
 import org.fosstrak.ale.exception.DuplicateNameException;
 import org.fosstrak.ale.exception.NoSuchNameException;
@@ -18,16 +19,19 @@ public interface LLRPController {
 
 	/**
 	 * define a new ROSpec on the given logical reader.
-	 * @param readerName the name of the reader where to define the ROSpec.
+	 * @param lrSpecName the name of the AddROSpec.
 	 * @param addRoSpec serialized AddROSpec
 	 * @throws DuplicateNameException
 	 * @throws NoSuchNameException
 	 */
 	@WebMethod
-	public void define(String readerName, String addRoSpec) throws DuplicateNameException, NoSuchNameException;	
+	public void define(String lrSpecName, String addRoSpec) throws DuplicateNameException, NoSuchNameException;
 	
 	@WebMethod
 	public void undefine(String lrSpecName) throws NoSuchNameException;
+
+	@WebMethod
+	public List<String> getSpecNames();
 	
 	@WebMethod
 	public void start (String lrSpecName) throws NoSuchNameException;

--- a/fc-server/src/main/java/org/fosstrak/ale/server/ac/ServerPasswordCallback.java
+++ b/fc-server/src/main/java/org/fosstrak/ale/server/ac/ServerPasswordCallback.java
@@ -24,7 +24,7 @@ public class ServerPasswordCallback implements CallbackHandler {
  
         WSPasswordCallback pc = (WSPasswordCallback) callbacks[0];
  
-        if (pc.getIdentifier().equals("limg00n")) {
+        if (pc.getIdentifier().equals("admin")) {
             // set the password on the callback. This will be compared to the
             // password which was sent from the client.
             //pc.setPassword("1111");

--- a/fc-server/src/main/java/org/fosstrak/ale/server/llrp/LLRPControllerImpl.java
+++ b/fc-server/src/main/java/org/fosstrak/ale/server/llrp/LLRPControllerImpl.java
@@ -8,6 +8,8 @@ import org.fosstrak.ale.exception.DuplicateNameException;
 import org.fosstrak.ale.exception.NoSuchNameException;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
+
 /**
  * ORANGE: This class defines the implementation of the Web Services LLRPController.
  * Define, Start, Stop, Enable, Disable ... an ROSPEC on a LLRP Reader. 
@@ -23,6 +25,16 @@ public class LLRPControllerImpl implements LLRPController {
 	@WebMethod
 	public void define(String lrSpecName, String addRoSpec) throws DuplicateNameException, NoSuchNameException {	
 		llrpControllerManager.define(lrSpecName, addRoSpec);		
+	}
+
+	@WebMethod
+	public void undefine(String lrSpecName) throws NoSuchNameException {
+		llrpControllerManager.undefine(lrSpecName);
+	}
+
+	@WebMethod
+	public List<String> getSpecNames() {
+		return llrpControllerManager.getSpecNames();
 	}
 
 	@WebMethod
@@ -49,12 +61,4 @@ public class LLRPControllerImpl implements LLRPController {
 	public void stop(String lrSpecName) throws NoSuchNameException {
 		llrpControllerManager.stop(lrSpecName);
 	}
-
-	@WebMethod
-	public void undefine(String lrSpecName) throws NoSuchNameException {
-		llrpControllerManager.undefine(lrSpecName);
-	}
-
-	
-	
 }

--- a/fc-server/src/main/java/org/fosstrak/ale/server/llrp/LLRPControllerManager.java
+++ b/fc-server/src/main/java/org/fosstrak/ale/server/llrp/LLRPControllerManager.java
@@ -4,8 +4,7 @@ package org.fosstrak.ale.server.llrp;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Properties;
+import java.util.*;
 
 import org.apache.log4j.Logger;
 import org.fosstrak.ale.exception.DuplicateNameException;
@@ -161,6 +160,14 @@ public class LLRPControllerManager  {
 		LOG.debug("End Undefine ROSPEC for " + lrSpecName);
 	}
 	
+	/**
+	 * Get defines RoSpec names.
+	 * @return List of RoSpec names
+	 */
+	public List<String> getSpecNames() {
+		LOG.debug("Get ROSPEC names");
+		return new ArrayList<String>(lrROSpecMap.keySet());
+	}
 	
 	/**
 	 * Starts the RoSpec defined on the logical reader

--- a/fc-server/src/main/resources/log4j.xml
+++ b/fc-server/src/main/resources/log4j.xml
@@ -18,30 +18,30 @@
 	</appender>
 
 	<category name="org.fosstrak">
-		<priority value="INFO" />
+		<priority value="DEBUG" />
 		<!-- priority value="DEBUG" /-->
 	</category>
 
 	<category name="org.fosstrak.ale">
-		<priority value="INFO" />
+		<priority value="DEBUG" />
 		<!-- priority value="DEBUG" /-->
 	</category>
 	
 	<category name="org.fosstrak.hal.impl.sim.BatchSimulator">
-		<priority value="ERROR" />
+		<priority value="DEBUG" />
 	</category>
 	
 	<category name="org.fosstrak.hal.impl.sim.SimulatorController">
-		<priority value="ERROR" />
+		<priority value="DEBUG" />
 	</category>
 	
 	<category name="org.llrp.ltk">
 		<!-- priority value="DEBUG" /-->
-		<priority value="ERROR" />
+		<priority value="DEBUG" />
 	</category>
 	
 	<category name="kr.ac.kaist.resl.ltk.generated">
-		<priority value="ERROR" />
+		<priority value="DEBUG" />
 		<!-- priority value="DEBUG" /-->
 	</category>
 	

--- a/fc-server/src/main/resources/log4j.xml
+++ b/fc-server/src/main/resources/log4j.xml
@@ -47,7 +47,7 @@
 	
 	<category name="org.fosstrak.ale.server.readers.llrp">
 		<!--priority value="ERROR" /-->
-		<priority value="ERROR" />
+		<priority value="DEBUG" />
 	</category>
 
 	<root>

--- a/fc-server/src/main/resources/log4j.xml
+++ b/fc-server/src/main/resources/log4j.xml
@@ -18,36 +18,36 @@
 	</appender>
 
 	<category name="org.fosstrak">
-		<priority value="DEBUG" />
+		<priority value="INFO" />
 		<!-- priority value="DEBUG" /-->
 	</category>
 
 	<category name="org.fosstrak.ale">
-		<priority value="DEBUG" />
+		<priority value="INFO" />
 		<!-- priority value="DEBUG" /-->
 	</category>
 	
 	<category name="org.fosstrak.hal.impl.sim.BatchSimulator">
-		<priority value="DEBUG" />
+		<priority value="ERROR" />
 	</category>
 	
 	<category name="org.fosstrak.hal.impl.sim.SimulatorController">
-		<priority value="DEBUG" />
+		<priority value="ERROR" />
 	</category>
 	
 	<category name="org.llrp.ltk">
 		<!-- priority value="DEBUG" /-->
-		<priority value="DEBUG" />
+		<priority value="ERROR" />
 	</category>
 	
 	<category name="kr.ac.kaist.resl.ltk.generated">
-		<priority value="DEBUG" />
+		<priority value="ERROR" />
 		<!-- priority value="DEBUG" /-->
 	</category>
 	
 	<category name="org.fosstrak.ale.server.readers.llrp">
 		<!--priority value="ERROR" /-->
-		<priority value="DEBUG" />
+		<priority value="ERROR" />
 	</category>
 
 	<root>


### PR DESCRIPTION
Fixes:
 * Service class was hardcoded in AbstractTab to use ALETM, but it's not right for other services. Now each tab uses own service class.
 * Solve the secure XML creation error by allowing insecure XML creation in CXF.
 * Remove dual dependency from fc-client pom.xml: log4j is already in fc-common. Otherwise it's not possible to easily launch fc-client from command line.

Updates:
 * Changed server SOAP access user name to "admin".
 * Added option to provide client.properties as command line argument while keeping previous resource file providing option (which is used as default, when no argument is provided).
 * Make the SOAP message WS-Security headers usage configurable with "useWsse" property (in client.properties file/resource). Default is "false". This is needed for backward compatibility with fosstrak and Rifidi.
 * Added LLRP Controller service tab to configure LLRP readers in fc-server.
 * Added fc-server webmethod to get LLRP ROSpec names so fc-client can display the names in combo box.
 * Let client UI pick first available spec from combo boxes (in all service tabs).

Note:
 * LLRP define service is special. Unlike other ALE specs, the LLRP ROspec file content is not sent to server. Instead the file path string is sent. This means if the fc-server runs in another machine than the fc-client, the file path has to be the fc-server's file path.