### PR TITLE
LLRP adapter fixes

### DIFF
--- a/fc-server/src/main/java/kr/ac/kaist/resl/fosstrak/ale/ReaderImpl.java
+++ b/fc-server/src/main/java/kr/ac/kaist/resl/fosstrak/ale/ReaderImpl.java
@@ -322,8 +322,8 @@ public class ReaderImpl extends UnicastRemoteObject implements LLRPEndpoint, Rea
 	private void sendLLRPMessage(LLRPMessage llrpMessage) throws RemoteException {
 		try {
 			// send the message asynchronous.
-			//connector.send(llrpMessage);
-			ioSession.write(llrpMessage);
+			connector.send(llrpMessage);
+			//ioSession.write(llrpMessage); // TODO Oliot project used this instead connector.send
 			metaData._packageSent();
 		} catch (NullPointerException npe) {
 			// a null-pointer exception occurs when the reader is no more connected.

--- a/fc-server/src/main/java/org/fosstrak/ale/server/cc/impl/CommandCycleImpl.java
+++ b/fc-server/src/main/java/org/fosstrak/ale/server/cc/impl/CommandCycleImpl.java
@@ -239,6 +239,11 @@ public final class CommandCycleImpl implements CommandCycle, Runnable {
 		}
 		
 		for (LogicalReader logicalReader : logicalReaders) {
+
+			// Start the reader
+			if (!logicalReader.isStarted()) {
+				logicalReader.start();
+			}
 			
 			// subscribe this command cycle to the logical readers
 			LOG.debug("registering CommandCycle " + name + " on reader " + logicalReader.getName());

--- a/fc-server/src/main/java/org/fosstrak/ale/server/impl/EventCycleImpl.java
+++ b/fc-server/src/main/java/org/fosstrak/ale/server/impl/EventCycleImpl.java
@@ -227,10 +227,14 @@ public final class EventCycleImpl implements EventCycle, Runnable {
 		}
 		
 		for (LogicalReader logicalReader : logicalReaders) {
-			
+
+			// Start the reader
+			if (!logicalReader.isStarted()) {
+				logicalReader.start();
+			}
+
 			// subscribe this event cycle to the logical readers
 			LOG.debug("registering EventCycle " + name + " on reader " + logicalReader.getName());
-			
 			logicalReader.addObserver(this);
 		}
 		

--- a/fc-server/src/main/java/org/fosstrak/ale/server/llrp/LLRPControllerManager.java
+++ b/fc-server/src/main/java/org/fosstrak/ale/server/llrp/LLRPControllerManager.java
@@ -110,13 +110,24 @@ public class LLRPControllerManager  {
 			String readerName= retrievePhysicalReader (lrSpecName);
 			getLLRPConfiguration();
 			initClientConnection(readerName);
+
+			// TODO Should check for responses of all the commands which are sent down here:
+
+			// First delete possible previous ROSPECs.
+			// This is important when using real readers which may not accept over-defining the spec.
+			DELETE_ROSPEC deleteROSpec = new DELETE_ROSPEC();
+			deleteROSpec.setROSpecID(new UnsignedInteger(0));
+			AdaptorMgmt.sendLLRPMessage(readerName, deleteROSpec);
+
 			// add ROSpec
 			AdaptorMgmt.sendLLRPMessage(readerName, addRoSpec);
+
 			// enable the ROSpec
 			ENABLE_ROSPEC enableROSpec = new ENABLE_ROSPEC();
 			UnsignedInteger roSpecId = addRoSpec.getROSpec().getROSpecID();
 			enableROSpec.setROSpecID(roSpecId);
 			AdaptorMgmt.sendLLRPMessage(readerName, enableROSpec);
+
 			// init the internal data
 			lrROSpecMap.put(lrSpecName, addRoSpec.getROSpec());
 			physicalLRMap.put(readerName, lrSpecName);
@@ -124,6 +135,7 @@ public class LLRPControllerManager  {
 			lrPhysicalMap.put(lrSpecName, readerName);
 			//TODO: case of composite reader
 			lrLLRPCheckMap.put(lrSpecName, new LLRPChecking(readerName));
+
 			// persistence
 			ALEApplicationContext.getBean(WriteConfig.class).writeAddROSpec(lrSpecName, addRoSpec);
 			LOG.debug("End Define an ADD_ROSPEC for " + lrSpecName);

--- a/fc-server/src/main/java/org/fosstrak/ale/server/readers/CompositeReader.java
+++ b/fc-server/src/main/java/org/fosstrak/ale/server/readers/CompositeReader.java
@@ -76,7 +76,12 @@ public class CompositeReader extends LogicalReader implements Observer  {
 				
 				// just retrieve the reader from the LogicalReaderManager
 				LogicalReader logicalReader = logicalReaderManager.getLogicalReader(reader);
-				
+
+				// Start the reader
+				if (!logicalReader.isStarted()) {
+					logicalReader.start();
+				}
+
 				// add the reader to the observable
 				logicalReader.addObserver(this);
 				logicalReaders.put(logicalReader.getName(), logicalReader);
@@ -197,6 +202,13 @@ public class CompositeReader extends LogicalReader implements Observer  {
 				// fill in the new readers
 				for (String reader : readers) {
 					LogicalReader logicalReader = logicalReaderManager.getLogicalReader(reader);
+
+					// Start the reader
+					if (!logicalReader.isStarted()) {
+						logicalReader.start();
+					}
+
+					// add the reader to the observable
 					logicalReader.addObserver(this);
 					logicalReaders.put(reader, logicalReader);
 				}

--- a/fc-server/src/main/java/org/fosstrak/ale/server/readers/impl/LogicalReaderManagerImpl.java
+++ b/fc-server/src/main/java/org/fosstrak/ale/server/readers/impl/LogicalReaderManagerImpl.java
@@ -396,16 +396,7 @@ public class LogicalReaderManagerImpl implements LogicalReaderManager {
 
 	@Override
 	public LogicalReader getLogicalReader(String readerName) {
-		
-		LogicalReader reader = null;
-		if (logicalReaders.containsKey(readerName)) {
-			reader = logicalReaders.get(readerName);
-			
-			if (!reader.isStarted()) {
-				reader.start();
-			}
-		}
-		return reader;
+		return logicalReaders.getOrDefault(readerName, null);
 	}
 
 	@Override

--- a/fc-server/src/main/java/org/fosstrak/ale/server/readers/llrp/LLRPAdaptor.java
+++ b/fc-server/src/main/java/org/fosstrak/ale/server/readers/llrp/LLRPAdaptor.java
@@ -554,9 +554,13 @@ public class LLRPAdaptor extends BaseReader {
 		}
 
 		ReaderInitiatedConnectionEntry entry = null;
-		if((entry = PhysicalReaderAcceptor.mapIdAndReaderInitiatedConnectionEntry.get(physicalReaderId)) != null) {
-			MultipleLLRPEndpoint endpoints = entry.getEndpoint();
-			endpoints.removeLLRPEndpoint((ReaderImpl)reader);
+
+		// Physical reader connection might have failed, so can't trust that it is mapped.
+		if ((physicalReaderId != null) && (PhysicalReaderAcceptor.mapIdAndReaderInitiatedConnectionEntry.containsKey(physicalReaderId))) {
+			if ((entry = PhysicalReaderAcceptor.mapIdAndReaderInitiatedConnectionEntry.get(physicalReaderId)) != null) {
+				MultipleLLRPEndpoint endpoints = entry.getEndpoint();
+				endpoints.removeLLRPEndpoint((ReaderImpl) reader);
+			}
 		}
 	}
 

--- a/fc-server/src/main/java/org/fosstrak/ale/server/readers/llrp/LLRPManager.java
+++ b/fc-server/src/main/java/org/fosstrak/ale/server/readers/llrp/LLRPManager.java
@@ -45,7 +45,7 @@ import org.springframework.stereotype.Service;
 public class LLRPManager implements LLRPExceptionHandler, MessageHandler {
 	
 	/** the path to the configuration file. */
-	public static final String CONFIGURATION_FILE = "/llrpAdaptorConfiguration.properties";
+	public static final String CONFIGURATION_FILE = "/LLRPAdaptorConfig.properties";
 	
 	/** the name of the property of the adapter management configuration file.*/
 	public static final String PROP_MGMT_CFG = "mgmt";

--- a/fc-server/src/test/java/org/fosstrak/ale/server/readers/test/CompositeReaderTest.java
+++ b/fc-server/src/test/java/org/fosstrak/ale/server/readers/test/CompositeReaderTest.java
@@ -145,6 +145,9 @@ public class CompositeReaderTest {
 
 		LogicalReader logicalReader = EasyMock.createMock(LogicalReader.class);
 		EasyMock.expect(logicalReader.getName()).andReturn(logicalReaderName1).atLeastOnce();
+		EasyMock.expect(logicalReader.isStarted()).andReturn(false).once();
+		logicalReader.start();
+		EasyMock.expectLastCall().once();
 		logicalReader.addObserver(compositeReader);
 		EasyMock.expectLastCall();
 		logicalReader.deleteObserver(compositeReader);

--- a/fc-server/src/test/java/org/fosstrak/ale/server/readers/test/LogicalReaderManagerTest.java
+++ b/fc-server/src/test/java/org/fosstrak/ale/server/readers/test/LogicalReaderManagerTest.java
@@ -107,15 +107,10 @@ public class LogicalReaderManagerTest {
 		
 		LogicalReader logicalReader1 = EasyMock.createMock(LogicalReader.class);
 		EasyMock.expect(logicalReader1.getName()).andReturn("reader1").atLeastOnce();
-		EasyMock.expect(logicalReader1.isStarted()).andReturn(false).atLeastOnce();
-		// start is invoked at least once (as mock is always returning not-started).
-		logicalReader1.start();
-		EasyMock.expectLastCall().atLeastOnce();
 		EasyMock.replay(logicalReader1);
 		
 		LogicalReader logicalReader2 = EasyMock.createMock(LogicalReader.class);
 		EasyMock.expect(logicalReader2.getName()).andReturn("reader2").atLeastOnce();
-		EasyMock.expect(logicalReader2.isStarted()).andReturn(true).atLeastOnce();
 		EasyMock.replay(logicalReader2);
 		
 		// test setters and getters -----------------

--- a/fc-server/src/test/java/org/fosstrak/ale/server/test/EventCycleTest.java
+++ b/fc-server/src/test/java/org/fosstrak/ale/server/test/EventCycleTest.java
@@ -91,6 +91,9 @@ public class EventCycleTest {
 		final String logicalReaderName1 = "LogicalReader1";
 		LogicalReader lr1 = EasyMock.createMock(LogicalReader.class);
 		EasyMock.expect(lr1.getName()).andReturn(logicalReaderName1).anyTimes();
+		EasyMock.expect(lr1.isStarted()).andReturn(false).once();
+		lr1.start();
+		EasyMock.expectLastCall().once();
 		lr1.addObserver(EasyMock.isA(EventCycle.class));
 		EasyMock.expectLastCall().anyTimes();
 		EasyMock.replay(lr1);


### PR DESCRIPTION
Fixes:
 * Fix logical reader undefine function which didn't work if the define wasn't successful (reader wasn't connected successfully). It resulted in a faulty state where reader wasn't functioning and it was impossible to re-define it also.
 * Restoring Fosstrack LLRP connection method (in ReaderImpl.sendLLRPMessage function). I don't fully understand what's been added by Oliot, but it broke the support for LLRP readers which are LLRP servers and require client connection.
 * Delete previous ROSPEC(s) before sending new one. This was the issue with Impinj Speedway reader, when undefine wasn't sent.
 * Do not start reader in getLogicalReader function. Start it only when needed, not when getting reader in undefine method  because undefine should stop reader, not start it.
